### PR TITLE
add prog to gen pythagorean triples

### DIFF
--- a/basic-functions.hs
+++ b/basic-functions.hs
@@ -157,4 +157,6 @@ positions x xs = [i | (x',i) <- zip xs [0..], x'==x ]
 count :: Char -> String -> Int
 count x xs = length [x'| x' <- xs, x' == x]
 
-
+--- find pythagorean triples
+pyths :: Int -> [(Int,Int,Int)]
+pyths n = [(x,y,z) | x <- [1..n], y <- [1..n], z <- [1..n], x*x + y*y == z*z] 


### PR DESCRIPTION
add small code to generate pythagorean triples

usage: pyths 5
[(3,4,5),(4,3,5)]
ghci> pyths 50
[(3,4,5),(4,3,5),(5,12,13),(6,8,10),(7,24,25),(8,6,10),(8,15,17),(9,12,15),(9,40,41),(10,24,26),(12,5,13),(12,9,15),(12,16,20),(12,35,37),(14,48,50),(15,8,17),(15,20,25),(15,36,39),(16,12,20),(16,30,34),(18,24,30),(20,15,25),(20,21,29),(21,20,29),(21,28,35),(24,7,25),(24,10,26),(24,18,30),(24,32,40),(27,36,45),(28,21,35),(30,16,34),(30,40,50),(32,24,40),(35,12,37),(36,15,39),(36,27,45),(40,9,41),(40,30,50),(48,14,50)]